### PR TITLE
add GetField func to get an specific field from logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ To retrieve stored zap fields in context and log them :
 
      logger.With(zax.Get(ctx)...).Info("just a test record")
 
+To retrieve an specific field in the context you can use zax.GetField:
+
+     zax.GetField(ctx, "trace_id")
 
 After that, you can use the output as a regular logger and perform logging operations:
 

--- a/zax.go
+++ b/zax.go
@@ -34,3 +34,15 @@ func Get(ctx context.Context) []zap.Field {
 	}
 	return nil
 }
+
+// GetField Get a specific zap stored field from context by key
+func GetField(ctx context.Context, key string) (field zap.Field) {
+	if loggerFields, ok := ctx.Value(loggerKey).([]zap.Field); ok {
+		for _, field := range loggerFields {
+			if field.Key == key {
+				return field
+			}
+		}
+	}
+	return
+}

--- a/zax_test.go
+++ b/zax_test.go
@@ -162,3 +162,28 @@ func TestGet(t *testing.T) {
 		})
 	}
 }
+func TestGetField(t *testing.T) {
+	traceIDKey := traceIDKey
+	ctx := context.Background()
+	tests := map[string]struct {
+		context       context.Context
+		expectedValue string
+	}{
+		"context empty": {
+			context:       context.TODO(),
+			expectedValue: "",
+		},
+		"context with trace-id field": {
+			context:       Set(ctx, []zap.Field{zap.String(traceIDKey, testTraceID)}),
+			expectedValue: testTraceID,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := tc.context
+			field := GetField(ctx, traceIDKey)
+			assert.Equal(t, tc.expectedValue, field.String)
+		})
+	}
+}


### PR DESCRIPTION
Adding `GetField` to retrieve a specific field from the stored fields from the logger.

eg:  `zax.GetField(ctx, "traceID")` this returns traceID zap field from the context . if it does not exist return empty zap.field.

