### PR TITLE
fix: assign set result to ctx

### DIFF
--- a/zax_benchmark_test.go
+++ b/zax_benchmark_test.go
@@ -20,7 +20,7 @@ func LogWithZap(logger *zap.Logger) {
 
 func LogWithZax(logger *zap.Logger) {
 	ctx := context.Background()
-	Set(ctx, someFields)
+	ctx = Set(ctx, someFields)
 	logger.With(Get(ctx)...).Info("logging something")
 }
 


### PR DESCRIPTION
- closes: #23 

## Description
- Fix `LogWithZax` function in the benchmark test to log added fields correctly.

Benchmark test function `BenchmarkLoggingWithZax` in `zax_benchmark_test.go` will not print added fields to context, unless context is properly provided.

in order to provide fields attached to ctx, the outcome of Set function should be reassigned to ctx.
```go
ctx = Set(ctx, someFields) // assign result of Set to ctx.
logger.With(Get(ctx)...).Info("logging something")
```

## How to test
Just make the benchmark function to print logs:

```go
func BenchmarkLoggingWithZax(b *testing.B) {
	// Create a no-op logger that discards log output
	logger := zap.NewExample()
	logger = logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
		enc := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
		return zapcore.NewCore(enc, zapcore.AddSync(os.Stderr), zapcore.InfoLevel)
	}))

	for i := 1; i <= b.N; i++ {
		LogWithZax(logger)
	}
}
```

Result:
```
...
{"level":"info","ts":1742721091.128562,"msg":"logging something","field1":"value1","field2":"value2","field3":2}
{"level":"info","ts":1742721091.128564,"msg":"logging something","field1":"value1","field2":"value2","field3":2}
{"level":"info","ts":1742721091.128565,"msg":"logging something","field1":"value1","field2":"value2","field3":2}
{"level":"info","ts":1742721091.128567,"msg":"logging something","field1":"value1","field2":"value2","field3":2}
BenchmarkLoggingWithZax-8          24927             48147 ns/op            1369 B/op          7 allocs/op
PASS
ok      github.com/yuseferi/zax/v2      2.143s
```

