### PR TITLE
feat: fix GetSugared to support sugared logger to support more type

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ func (s *ServiceA) funcA(ctx context.Context) {
     s.logger.Info("func A") // it does not contain trace_id, you need to add it manually
 	s.logger.With(zax.Get(ctx)...).Info("func A") // it will logged with "trace_id" = "my-trace-id"
 }
-
 ```
+
+
 ### benchmark
 We have benchmarked Zax V2,V1 and Zap using the same fields. Here are the benchmark results:
 As you can see in **V2** (Method with storing only fields in context, has better performance than V1 ( storing the whole logger object in context))

--- a/zax_test.go
+++ b/zax_test.go
@@ -193,9 +193,10 @@ func TestGetSugared(t *testing.T) {
 		t.Run(
 			name, func(t *testing.T) {
 				ctx := tc.context
-				sugar.With(GetSugared(ctx)...).Info("just a test record")
+				sugar.With(GetSugared(ctx)...).Errorf("just a test record")
 				if tc.expectedLoggerKey != nil {
 					testLog.AssertLogEntryKeyExist(t, *tc.expectedLoggerKey)
+					testLog.AssertLogEntryExist(t, *tc.expectedLoggerKey, testTraceID)
 				}
 			},
 		)


### PR DESCRIPTION
support more types in `GetSugared`.

In the early version, it was only supported `interface`, but now it supports `String, Bool, Int, Error and Interface.` types.